### PR TITLE
One element tuple params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # libpypa - A Python Parser Library in C++
 
+[![Join the chat at https://gitter.im/vinzenz/libpypa](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vinzenz/libpypa?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 - [Introduction](#introduction)
  - [Motivation](#introduction-motivation)
  - [Goal](#introduction-goal)

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2053,7 +2053,6 @@ bool dictorsetmaker(State & s, AstExpr & ast) {
                 ptr->elements.push_back(first);
                 while(expect(s, TokenKind::Comma)) {
                     if(!test(s, first)) {
-                        syntax_error(s, ast, "Expected expression after `,`");
                         break;
                     }
                     ptr->elements.push_back(first);

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -77,7 +77,7 @@ void add_symbol_error(State & s, char const * message, int line, int column, int
 
 void syntax_error_dbg(State & s, AstPtr ast, char const * message, int line = -1, char const * file = 0, char const * function = 0) {
     TokenInfo cur = top(s);
-    if(ast && cur.line > ast->line) {
+    if(ast && cur.line < ast->line) {
         cur.line    = ast->line;
         cur.column  = ast->column;
     }

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2137,13 +2137,15 @@ bool fplist(State & s, AstExpr & ast) {
     AstExpr temp;
     if(fpdef(s, temp)) {
         tuple->elements.push_back(temp);
+        bool any_commas = false;
         while(expect(s, TokenKind::Comma)) {
+            any_commas = true;
             if(!fpdef(s, temp)) {
                 break;
             }
             tuple->elements.push_back(temp);
         }
-        if(tuple->elements.size() == 1) {
+        if(tuple->elements.size() == 1 && !any_commas) {
             ast = tuple->elements.front();
         }
         return guard.commit();

--- a/src/pypa/parser/parser_fwd.hh
+++ b/src/pypa/parser/parser_fwd.hh
@@ -43,7 +43,8 @@ namespace pypa {
     bool dictorsetmaker(State & s, AstExpr & ast);
     bool dotted_as_name(State & s, AstExpr & ast);
     bool dotted_as_names(State & s, AstExpr & ast);
-    bool dotted_name(State & s, AstExpr & ast, bool as_dotted_name);
+    bool dotted_name(State & s, AstExpr & ast);
+    bool dotted_name_list(State & s, AstExpr & ast);
 #if 0
     bool eval_input(State & s, AstModulePtr & ast);
 #endif


### PR DESCRIPTION
Previously we would parse

```
def f((a,)):
```

as

```
def f(a):
```
